### PR TITLE
hotplug: do not close neither

### DIFF
--- a/modules/infra/api/gr_infra.h
+++ b/modules/infra/api/gr_infra.h
@@ -91,6 +91,7 @@ struct __gr_iface_info_port_base {
 	uint16_t rxq_size;
 	uint16_t txq_size;
 	uint32_t link_speed; //!< Physical link speed in Megabit/sec.
+	bool hotplugged;
 	struct rte_ether_addr mac;
 };
 

--- a/modules/infra/cli/port.c
+++ b/modules/infra/cli/port.c
@@ -20,6 +20,7 @@ static void port_show(const struct gr_api_client *c, const struct gr_iface *ifac
 
 	printf("devargs: %s\n", port->devargs);
 	printf("driver:  %s\n", port->driver_name);
+	printf("hotplugged: %s\n", port->hotplugged ? "on" : "off");
 	printf("mac: " ETH_F "\n", &port->mac);
 	if (port->link_speed == UINT32_MAX)
 		printf("speed: unknown\n");

--- a/modules/infra/control/gr_port.h
+++ b/modules/infra/control/gr_port.h
@@ -33,7 +33,6 @@ struct __rte_aligned(alignof(void *)) iface_info_port {
 
 	uint16_t port_id;
 	bool started;
-	bool hotplugged;
 	struct rte_mempool *pool;
 	char *devargs;
 	uint32_t pool_size;

--- a/modules/infra/control/port.c
+++ b/modules/infra/control/port.c
@@ -307,7 +307,7 @@ static int iface_port_fini(struct iface *iface) {
 		LOG(ERR, "rte_eth_dev_info_get: %s", rte_strerror(-ret));
 	if ((ret = rte_eth_dev_stop(port->port_id)) < 0)
 		LOG(ERR, "rte_eth_dev_stop: %s", rte_strerror(-ret));
-	if ((ret = rte_eth_dev_close(port->port_id)) < 0)
+	if (port->hotplugged && (ret = rte_eth_dev_close(port->port_id)) < 0)
 		LOG(ERR, "rte_eth_dev_close: %s", rte_strerror(-ret));
 	if (port->hotplugged && info.device != NULL && (ret = rte_dev_remove(info.device)) < 0)
 		LOG(ERR, "rte_dev_remove: %s", rte_strerror(-ret));


### PR DESCRIPTION
The enclosed serie has been tested "ok". If we do close, then we keep having the error:
```
error: command failed: Identifier removed
```

+ a small cosmetic on the `show interface` for the ports.